### PR TITLE
HTML5 drawTiles

### DIFF
--- a/haxelib/aze/display/SparrowTilesheet.hx
+++ b/haxelib/aze/display/SparrowTilesheet.hx
@@ -36,7 +36,7 @@ class SparrowTilesheet extends TilesheetEx
 				else 
 					new Rectangle(0,0, rect.width, rect.height);
 
-			#if (flash||js)
+			#if flash
 			var bmp = new BitmapData(cast size.width, cast size.height, true, 0);
 			ins.x = -size.left;
 			ins.y = -size.top;

--- a/haxelib/aze/display/TileGroup.hx
+++ b/haxelib/aze/display/TileGroup.hx
@@ -15,7 +15,7 @@ import nme.display.Sprite;
 class TileGroup extends TileBase
 {
 	public var children:Array<TileBase>;
-	#if (flash||js)
+	#if flash
 	var container:Sprite;
 	#end
 
@@ -23,7 +23,7 @@ class TileGroup extends TileBase
 	{
 		super();
 		children = new Array<TileBase>();
-		#if (flash||js)
+		#if flash
 		container = new Sprite();
 		#end
 	}
@@ -34,7 +34,7 @@ class TileGroup extends TileBase
 		initChildren();
 	}
 
-	#if (flash||js)
+	#if flash
 	override public function getView():DisplayObject { return container; }
 	#end
 
@@ -59,7 +59,7 @@ class TileGroup extends TileBase
 	public function addChild(item:TileBase)
 	{
 		removeChild(item);
-		#if (flash||js)
+		#if flash
 		container.addChild(item.getView());
 		#end
 		initChild(item);
@@ -69,7 +69,7 @@ class TileGroup extends TileBase
 	public function addChildAt(item:TileBase, index:Int)
 	{
 		removeChild(item);
-		#if (flash||js)
+		#if flash
 		container.addChildAt(item.getView(), index);
 		#end
 		initChild(item);
@@ -87,7 +87,7 @@ class TileGroup extends TileBase
 		var index = indexOf(item);
 		if (index >= 0) 
 		{
-			#if (flash||js)
+			#if flash
 			container.removeChild(item.getView());
 			#end
 			children.splice(index, 1);
@@ -98,7 +98,7 @@ class TileGroup extends TileBase
 
 	public function removeChildAt(index:Int)
 	{
-		#if (flash||js)
+		#if flash
 		container.removeChildAt(index);
 		#end
 		var child = children.splice(index, 1)[0];
@@ -108,7 +108,7 @@ class TileGroup extends TileBase
 
 	public function removeAllChildren()
 	{
-		#if (flash||js)
+		#if flash
 		while (container.numChildren > 0) container.removeChildAt(0);
 		#end
 		for (child in children)
@@ -124,7 +124,7 @@ class TileGroup extends TileBase
 	public inline function iterator() { return children.iterator(); }
 
 	public var numChildren(get_numChildren, null):Int;
-	inline function get_numChildren() { return children.length; }
+	inline function get_numChildren() { return children != null ? children.length : 0; }
 
 	public var height(get_height, null):Float; // TOFIX incorrect with sub groups
 	function get_height():Float 

--- a/haxelib/aze/display/TileLayer.hx
+++ b/haxelib/aze/display/TileLayer.hx
@@ -1,6 +1,5 @@
 package aze.display;
 
-import flash.geom.Matrix;
 import haxe.Public;
 import nme.display.Bitmap;
 import nme.display.BitmapData;
@@ -8,6 +7,7 @@ import nme.display.BlendMode;
 import nme.display.DisplayObject;
 import nme.display.Graphics;
 import nme.display.Sprite;
+import nme.geom.Matrix;
 import nme.geom.Rectangle;
 import nme.Lib;
 
@@ -54,7 +54,7 @@ class TileLayer extends TileGroup
 		drawList.begin(elapsed == null ? 0 : elapsed, useTransforms, useAlpha, useTint, useAdditive);
 		renderGroup(this, 0, 0, 0);
 		drawList.end();
-		#if (flash||js)
+		#if flash
 		view.addChild(container);
 		#else
 		view.graphics.clear();
@@ -72,7 +72,7 @@ class TileLayer extends TileGroup
 		var offsetAlpha = drawList.offsetAlpha;
 		var elapsed = drawList.elapsed;
 
-		#if (flash||js)
+		#if flash
 		group.container.x = gx + group.x;
 		group.container.y = gy + group.y;
 		var blend = useAdditive ? BlendMode.ADD : BlendMode.NORMAL;
@@ -80,7 +80,7 @@ class TileLayer extends TileGroup
 		gx += group.x;
 		gy += group.y;
 		#end
-
+		
 		var n = group.numChildren;
 		for(i in 0...n)
 		{
@@ -103,7 +103,7 @@ class TileLayer extends TileGroup
 			{
 				var sprite:TileSprite = cast child;
 
-				#if (flash||js)
+				#if flash
 				if (sprite.visible && sprite.alpha > 0.0)
 				{
 					var m = sprite.bmp.transform.matrix;
@@ -173,7 +173,7 @@ class TileBase implements Public
 	{
 	}
 
-	#if (flash||js)
+	#if flash
 	function getView():DisplayObject { return null; }
 	#end
 }
@@ -204,28 +204,28 @@ class DrawList implements Public
 
 	function begin(elapsed:Int, useTransforms:Bool, useAlpha:Bool, useTint:Bool, useAdditive:Bool) 
 	{
-		#if (cpp||neko)
+		#if !flash
 		flags = 0;
 		fields = 3;
 		if (useTransforms) {
 			offsetTransform = fields;
 			fields += 4;
-			flags |= neash.display.Graphics.TILE_TRANS_2x2;
+			flags |= Graphics.TILE_TRANS_2x2;
 		}
 		else offsetTransform = 0;
 		if (useTint) {
 			offsetRGB = fields; 
 			fields+=3; 
-			flags |= neash.display.Graphics.TILE_RGB;
+			flags |= Graphics.TILE_RGB;
 		}
 		else offsetRGB = 0;
 		if (useAlpha) {
 			offsetAlpha = fields; 
 			fields++; 
-			flags |= neash.display.Graphics.TILE_ALPHA;
+			flags |= Graphics.TILE_ALPHA;
 		}
 		else offsetAlpha = 0;
-		if (useAdditive) flags |= neash.display.Graphics.TILE_BLEND_ADD;
+		if (useAdditive) flags |= Graphics.TILE_BLEND_ADD;
 		#end
 
 		if (elapsed > 0) this.elapsed = elapsed;

--- a/haxelib/aze/display/TileSprite.hx
+++ b/haxelib/aze/display/TileSprite.hx
@@ -22,7 +22,7 @@ class TileSprite extends TileBase
 	var _scaleY:Float;
 	var _mirror:Int;
 
-	#if (cpp||neko)
+	#if !flash
 	var _transform:Array<Float>;
 	#else
 	var _matrix:Matrix;
@@ -43,7 +43,7 @@ class TileSprite extends TileBase
 		dirty = true;
 		this.tile = tile;
 		_indice = -1;
-		#if (flash||js)
+		#if flash
 		bmp = new Bitmap();
 		bmp.y = -9999; // jeash flicker
 		_matrix = new Matrix();
@@ -60,7 +60,7 @@ class TileSprite extends TileBase
 		size = layer.tilesheet.getSize(indice);
 	}
 
-	#if (flash||js)
+	#if flash
 	override public function getView():DisplayObject { return bmp; }
 	#end
 
@@ -82,7 +82,7 @@ class TileSprite extends TileBase
 		if (_indice != value)
 		{
 			_indice = value;
-			#if (flash||js)
+			#if flash
 			bmp.bitmapData = layer.tilesheet.getBitmap(value);
 			bmp.smoothing = layer.useSmoothing;
 			#end
@@ -161,7 +161,7 @@ class TileSprite extends TileBase
 		return value;
 	}
 
-	#if (cpp||neko)
+	#if !flash
 	public var transform(get_transform, null):Array<Float>;
 	function get_transform():Array<Float>
 	{

--- a/haxelib/aze/display/TilesheetEx.hx
+++ b/haxelib/aze/display/TilesheetEx.hx
@@ -1,20 +1,11 @@
 package aze.display;
 
 import nme.display.BitmapData;
+import nme.display.Tilesheet;
 import nme.geom.Point;
 import nme.geom.Rectangle;
 
 using StringTools;
-
-// graceful Jeash compatibility
-#if js
-class Tilesheet { 
-	function new(img:BitmapData) {
-	}
-}
-#else
-typedef Tilesheet = nme.display.Tilesheet;
-#end
 
 /**
  * A cross-targets Tilesheet container, with animation and trimming support
@@ -31,7 +22,7 @@ class TilesheetEx extends Tilesheet
 	var defs:Array<String>;
 	var sizes:Array<Rectangle>;
 	var anims:Hash<Array<Int>>;
-	#if (flash||js)
+	#if flash
 	var bmps:Array<BitmapData>;
 	#end
 
@@ -42,12 +33,12 @@ class TilesheetEx extends Tilesheet
 		defs = new Array<String>();
 		anims = new Hash<Array<Int>>();
 		sizes = new Array<Rectangle>();
-		#if (flash||js)
+		#if flash
 		bmps = new Array<BitmapData>();
 		#end
 	}
 
-	#if (flash||js)
+	#if flash
 	function addDefinition(name:String, size:Rectangle, bmp:BitmapData)
 	{
 		defs.push(name);
@@ -83,7 +74,7 @@ class TilesheetEx extends Tilesheet
 		else return new Rectangle();
 	}
 
-	#if (flash||js)
+	#if flash
 	inline public function getBitmap(indice:Int):BitmapData
 	{
 		return bmps[indice];
@@ -124,7 +115,7 @@ class TilesheetEx extends Tilesheet
 		{
 			var image = images[i];
 			img.copyPixels(image, image.rect, pos, null, null, true);
-			#if (flash||js)
+			#if flash
 			sheet.addDefinition(names[i], image.rect, image);
 			#else
 			var rect = new Rectangle(padding, pos.y, image.width, image.height);


### PR DESCRIPTION
This updates TileLayer to use drawTiles for HTML5.

Currently, HTML5 cannot support alpha or RGB in drawTiles. Technically, we could internally generate new canvas elements at the requested alpha, but I believe it would probably be better to explain this is not a supported feature, and allow the developer to pregenerate the bitmaps on their own?

Anyway, that's another discussion. drawTiles on HTML5 is performing much faster
