### PR TITLE
Fix for Flash target, so a TileGroup.visible property actually affects w...

### DIFF
--- a/haxelib/aze/display/TileLayer.hx
+++ b/haxelib/aze/display/TileLayer.hx
@@ -106,7 +106,7 @@ class TileLayer extends TileGroup
 				var sprite:TileSprite = cast child;
 
 				#if flash
-				if (sprite.visible && sprite.alpha > 0.0)
+				if (sprite.parent.visible && sprite.visible && sprite.alpha > 0.0)
 				{
 					var m = sprite.bmp.transform.matrix;
 					m.identity();


### PR DESCRIPTION
In Flash target, the `visible` property on TileGroup now affects whether the instance is rendered or not. 
